### PR TITLE
Add --startuptimeout CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ optional arguments:
   --domain DOMAIN       Insert the domain.
   --kernel KERNEL       Insert the kernel path.
   --poolsize POOLSIZE   Insert the kernel pool size.
+  --startuptimeout SECONDS
+                        Startup timeout (in seconds) for kernels in the pool.
   --cached              The server will cache the WL input expression.
   --lazy                The server will start the kernels on the first
                         request.
@@ -318,6 +320,24 @@ Folder          /Users/rdv/Desktop
 Index           index.wl
 ----------------------------------------------------------------------
 (Press CTRL+C to quit)
+```
+
+#### --startuptimeout SECONDS
+
+By default, an attempt to start a kernel will be aborted if the kernel is not ready after 20 seconds. If your application contains long-running initialization code, you may need to raise this timeout.
+```
+>>> python3 -m wolframwebengine
+(...)
+Kernel process started with PID: 485
+Socket exception: Failed to read any message from socket tcp://127.0.0.1:5106 after 20.0 seconds and 245 retries.
+Failed to start.
+
+
+>>> python3 -m wolframwebengine --startuptimeout 50
+(...)
+Kernel process started with PID: 511
+Connected to logging socket: tcp://127.0.0.1:5447
+Kernel 511 is ready. Startup took 35.43 seconds.
 ```
 
 #### --lazy 

--- a/wolframwebengine/cli/commands/runserver.py
+++ b/wolframwebengine/cli/commands/runserver.py
@@ -42,6 +42,13 @@ class Command(SimpleCommand):
             "--poolsize", default=1, help="Insert the kernel pool size.", type=int
         )
         parser.add_argument(
+            "--startuptimeout",
+            default=20,
+            help="Startup timeout (in seconds) for kernels in the pool.",
+            type=int,
+            metavar="SECONDS"
+        )
+        parser.add_argument(
             "--cached",
             default=False,
             help="The server will cache the WL input expression.",
@@ -88,7 +95,10 @@ class Command(SimpleCommand):
     def demo_path(self, *args):
         return module_path("wolframwebengine", "examples", "demo", *args)
 
-    def handle(self, domain, port, path, kernel, poolsize, lazy, index, demo, **opts):
+    def handle(self,
+        domain, port, path, kernel, poolsize, startuptimeout, 
+        lazy, index, demo, **opts
+    ):
 
         if demo is None or demo:
             path = self.demo_path(self.demo_choices[demo])
@@ -96,7 +106,10 @@ class Command(SimpleCommand):
         path = os.path.abspath(os.path.expanduser(path))
 
         try:
-            session = create_session(kernel, poolsize=poolsize)
+            session = create_session(kernel,
+                poolsize=poolsize,
+                STARTUP_TIMEOUT=startuptimeout
+            )
 
         except WolframKernelException as e:
             self.print(e)


### PR DESCRIPTION
This option adjusts the [`STARTUP_TIMEOUT` session parameter](https://github.com/WolframResearch/WolframClientForPython/blob/27cffef560eea8d16c02fe4086f42363604284b6/wolframclient/evaluation/kernel/kernelcontroller.py#L194) in the Wolfram Client Library for Python. This is useful when one has an init.m file that can take >20 seconds to run.